### PR TITLE
bug21909: Set behavior log order as recommender order

### DIFF
--- a/modules/bibdk_recommender/js/bibdk_recommender_covers.js
+++ b/modules/bibdk_recommender/js/bibdk_recommender_covers.js
@@ -36,10 +36,11 @@
     var types = recommendation.closest('.js-slick-recommender').attr('data-recomole-types').split(",");
     BibdkRecommenderBehavior.filters_type = types;
     var recommendations = [];
-    elem.closest('.slick-track').find('.bibdk-recommender-cover-placeholder').each(function(index, element) {
-      recommendations.push($(this).attr('data-pid'));
+    elem.closest('.slick-track').find('.slick__slide').not('.slick-cloned').each(function(index, element) {
+      recommendations.push($(this).find('.bibdk-recommender-cover-placeholder').attr('data-pid'));
     });
-    BibdkRecommenderBehavior.result = unique(recommendations);
+    // BibdkRecommenderBehavior.result = unique(recommendations);
+    BibdkRecommenderBehavior.result = recommendations;
     
     var url = Drupal.settings.basePath + Drupal.settings.pathPrefix + 'bibdk/behaviour/recommender/';
     

--- a/modules/bibdk_recommender/js/bibdk_recommender_covers.js
+++ b/modules/bibdk_recommender/js/bibdk_recommender_covers.js
@@ -104,11 +104,4 @@
     });
   };
   
-  // Removes duplicate values from an array.
-  function unique(array) {
-    return $.grep(array, function(el, index) {
-        return index === $.inArray(el, array);
-    });
-  }
-
 } (jQuery));

--- a/modules/bibdk_recommender/js/bibdk_recommender_covers.js
+++ b/modules/bibdk_recommender/js/bibdk_recommender_covers.js
@@ -39,7 +39,6 @@
     elem.closest('.slick-track').find('.slick__slide').not('.slick-cloned').each(function(index, element) {
       recommendations.push($(this).find('.bibdk-recommender-cover-placeholder').attr('data-pid'));
     });
-    // BibdkRecommenderBehavior.result = unique(recommendations);
     BibdkRecommenderBehavior.result = recommendations;
     
     var url = Drupal.settings.basePath + Drupal.settings.pathPrefix + 'bibdk/behaviour/recommender/';


### PR DESCRIPTION
Recommender på bib.dk skal returnere listen af recommendations i samme
rækkefølge i loggen, som modtaget fra recommenderen.

Accept:
Rækkefølgen af recommendations (pid'er) fra recommenderen (recomole) og
bib.dk-loggens result-felt er ens.