### PR TITLE
better user information

### DIFF
--- a/modules/bibdk_reservation/bibdk_reservation.module
+++ b/modules/bibdk_reservation/bibdk_reservation.module
@@ -343,14 +343,6 @@ function _bibdk_reservation_set_login_message() {
   drupal_set_message(t('It would be better for you if you were logged in: !link', array('!link' => $loginlink), array('context' => 'bibdk_reservation')), 'warning', FALSE);
 }
 
-function _bibdk_reservation_set_saou_login_message() {
-  $link = 'user/login';
-
-  $loginlink = l(t('login_link', array(), array('context' => 'bibdk_reservation')), $link);
-
-  drupal_set_message(t('log in to see if your favorite library gives access: !link', array('!link' => $loginlink), array('context' => 'bibdk_reservation')), 'warning', FALSE);
-}
-
 /**
  * Validation handler for bibdk_reservation_validate_email;
  */

--- a/modules/bibdk_reservation/includes/bibdk_reservation.messages.inc
+++ b/modules/bibdk_reservation/includes/bibdk_reservation.messages.inc
@@ -78,6 +78,9 @@ function bibdk_reservation_get_action_links($ids, $manifestation) {
   }
   else if ($manifestation->hasDirectLink()) {
     $links[]['#markup'] = _ting_openformat_render_direct_link($manifestation->getInfotext(), $manifestation);
+  } else {
+    $links[]['#markup'] = _ting_openformat_render_direct_link($manifestation->getInfotext(), $manifestation);
+    $links[]['#markup'] = t('drupal_text_' . $manifestation->getInfotext(), array(), array('context' => 'bibdk_reservation'));
   }
   return $links;
 }

--- a/modules/bibdk_reservation/includes/bibdk_reservation.messages.inc
+++ b/modules/bibdk_reservation/includes/bibdk_reservation.messages.inc
@@ -17,7 +17,12 @@ function bibdk_reservation_get_messages($bibdk_work_entity) {
  * @return array
  */
 function bibdk_reservation_get_actions($ids, $bibdk_work_entity) {
-  if($links = bibdk_reservation_get_action_links($ids, $bibdk_work_entity)) {
+  $parm = $bibdk_work_entity->getManifestations();
+  $manifestation = reset($parm);
+
+  if($links = bibdk_reservation_get_action_links($ids, $manifestation)) {
+    $header = $manifestation->isReservable() ? 'Alternative access' : 'Is not reservable';
+    $description = $manifestation->isReservable() ? 'description_text' : 'description_not_reservable';
     $form = array(
       '#type' => 'container',
       '#attributes' => array(
@@ -29,13 +34,13 @@ function bibdk_reservation_get_actions($ids, $bibdk_work_entity) {
     $form['header'] = array(
       '#theme' => 'html_tag',
       '#tag' => 'h2',
-      '#value' => t('Alternative access', array(), array('context' => 'bibdk_reservation')),
+      '#value' => t($header, array(), array('context' => 'bibdk_reservation')),
     );
 
     $form['description'] = array(
       '#theme' => 'html_tag',
       '#tag' => 'p',
-      '#value' => t('description_text', array(), array('context' => 'bibdk_reservation')),
+      '#value' => t($description, array(), array('context' => 'bibdk_reservation')),
       '#attributes' => array(
         'class' => array(
           'bibdk-reservation-links-description'
@@ -51,11 +56,8 @@ function bibdk_reservation_get_actions($ids, $bibdk_work_entity) {
   return $links;
 }
 
-function bibdk_reservation_get_action_links($ids, BibdkWork $bibdk_work_entity) {
+function bibdk_reservation_get_action_links($ids, $manifestation) {
   $links = array();
-
-  $parm = $bibdk_work_entity->getManifestations();
-  $manifestation = reset($parm);
 
   if ($link = bibdk_reservation_article_infomedia_link($manifestation)) {
     $links[] = $link;
@@ -71,15 +73,11 @@ function bibdk_reservation_get_action_links($ids, BibdkWork $bibdk_work_entity) 
   }
 
   if ($manifestation->hasDirectLink() && $manifestation->getRestrictedExtendedUse()) {
-    if (!user_is_logged_in()) {
-      // not logged in, do log on to see if your favorite library gives access
-    } else {
-      $links['wrapper']['item_list_link'] = bibdk_saou_link_to_soau_ressource($manifestation);
-    }
-  } else {
-    if ($manifestation->hasDirectLink()) {
-      $links[]['#markup'] = _ting_openformat_render_direct_link($manifestation->getInfotext(), $manifestation);
-    }
+    $links[]['#markup'] = t('Only restricted access', array(), array('context' => 'bibdk_reservation'));
+    $links[]['#markup'] = _ting_openformat_render_direct_link($manifestation->getInfotext(), $manifestation);
+  }
+  else if ($manifestation->hasDirectLink()) {
+    $links[]['#markup'] = _ting_openformat_render_direct_link($manifestation->getInfotext(), $manifestation);
   }
   return $links;
 }


### PR DESCRIPTION
SAOU er disablet, men der var lige et enkelt kald i bibdk_reservation, som vi ikke havde fået fjernet. I samme omgang besluttede vi at brugerne skal have nogle bedre beskeder - især når noget ikke kan bestilles + alle links skal vises i popup, så brugeren ikke skal tilbage i posten for at finde dem.