### PR TITLE
Feature/noconfigmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 libraries
+modules/dbc_composer
+modules/vip_core
 modules/ding_*
 modules/ting_*
 modules/ting-client
@@ -12,3 +14,4 @@ modules/dbc_zabbix
 themes/bibdk_theme
 tests/helpers.py
 tests/__pycache__
+vendor

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,8 @@ pipeline {
           if (BRANCH == 'master') {
             build job: 'Bibliotek DK/Deployments/staging'
             NAMESPACE = 'frontend-staging'
+          } else if (BRANCH == 'noconfigmaps') {
+            build job: 'Bibliotek DK/Deployments/no-configmap', parameters: [string(name: 'deploybranch', value: BRANCH)]
           } else {
             build job: 'Bibliotek DK/Deployments/features', parameters: [string(name: 'deploybranch', value: BRANCH)]
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,8 +124,6 @@ pipeline {
           if (BRANCH == 'master') {
             build job: 'Bibliotek DK/Deployments/staging'
             NAMESPACE = 'frontend-staging'
-          } else if (BRANCH == 'noconfigmaps') {
-            build job: 'Bibliotek DK/Deployments/no-configmap', parameters: [string(name: 'deploybranch', value: BRANCH)]
           } else {
             build job: 'Bibliotek DK/Deployments/features', parameters: [string(name: 'deploybranch', value: BRANCH)]
           }

--- a/docker/www/Dockerfile
+++ b/docker/www/Dockerfile
@@ -102,4 +102,4 @@ EXPOSE 80
 
 HEALTHCHECK CMD ["/healthcheck.sh"]
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/drupal_config.sh"]

--- a/docker/www/script/drupal_config.sh
+++ b/docker/www/script/drupal_config.sh
@@ -47,4 +47,5 @@ sed -i 's/;max_input_vars = 128M/max_input_vars = 2048/' $PHPINI
 # Enable mail sending
 echo "sendmail_path = /usr/bin/msmtp -t" >>$PHPINI
 
+/entrypoint.sh
 


### PR DESCRIPTION
Ingen configmaps til bibliotek.dk

Vores dockerfile var ikke automatisk sat op til at køre drupal_config.sh, det er jo egentlig ret fjollet.
Så hvis man kørte den udenfor K8S, ville man ikke få de opdateringer fra scriptet automatisk. Det gør man nu. 